### PR TITLE
Configure and Disable PS4 Controller Support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,13 +121,11 @@ jobs:
 
       - name: Package PS3 Firmware ZIP
         run: |
-          cp .pio/build/release/firmware.bin ./build/lumenlab-firmware.bin
-          cp .pio/build/release/bootloader.bin ./build/lumenlab-bootloader.bin
-          cp .pio/build/release/partitions.bin ./build/lumenlab-partitions.bin
-          zip -j ./build/lumenlab-firmware.zip \
-            ./build/lumenlab-firmware.bin \
-            ./build/lumenlab-bootloader.bin \
-            ./build/lumenlab-partitions.bin
+          mkdir -p build
+          zip -j build/lumenlab-firmware.zip \
+            .pio/build/release/firmware.bin \
+            .pio/build/release/bootloader.bin \
+            .pio/build/release/partitions.bin
 
 
       - name: Package PS4 Firmware ZIP


### PR DESCRIPTION
The PS4 controller was fully integrated into the LumenLab, mapping the buttons the same way as the PS3 controller. The integration was completed, however the PS4 controller has two deal-breaking flaws:
* The latency is astronomically slow. Despite following guides online on how to optimize the connection, it is too severely slow for gameplay.
* All directions of the joy sticks, L2, and R2 have a gigantic dead zone, and skyrockets to its max value (-512, 511). This could be normalized to prevent movement bursts, but this won't fix the dead zone issue.

After extensive testing, this integration effort will be suspended until a solution is found for these issues. Releases will only include the firmware for PS3 controllers.