### PR TITLE
Support Gameplay Controller Rumble

### DIFF
--- a/include/player/controller.h
+++ b/include/player/controller.h
@@ -4,6 +4,7 @@
 #include <Arduino.h>
 
 #include "player/controller-properties.h"
+#include "player/rumble.h"
 
 namespace Player
 {
@@ -32,6 +33,8 @@ namespace Player
 
     virtual AnalogStick leftAnalog() = 0;
     virtual AnalogStick rightAnalog() = 0;
+
+    virtual void rumble(RumbleOptions option) = 0;
 
     virtual const uint8_t rawButtonState(const ControllerButton button) const = 0;
     virtual const bool wasPressed(const ControllerButton button) const = 0;

--- a/include/player/ps3-controller.h
+++ b/include/player/ps3-controller.h
@@ -3,6 +3,7 @@
 
 #include <Ps3Controller.h>
 #include "player/controller.h"
+#include "player/rumble.h"
 
 namespace Player
 {
@@ -34,6 +35,8 @@ namespace Player
     AnalogStick leftAnalog() override;
     AnalogStick rightAnalog() override;
 
+    void rumble(RumbleOptions option);
+
     const uint8_t rawButtonState(const ControllerButton button) const;
     const bool wasPressed(const ControllerButton button) const;
     const bool wasPressedAndReleased(const ControllerButton button) const;
@@ -45,6 +48,9 @@ namespace Player
     ::Ps3Controller *controller;
     static Ps3Controller *instance;
 
+    static void playRumblePattern(RumbleStep *pattern, int steps);
+    static void rumbleTask(void *pvParameters);
+    void triggerRumble(RumbleStep *pattern);
     void handleOnConnect();
     static void onConnect()
     {

--- a/include/player/ps3-controller.h
+++ b/include/player/ps3-controller.h
@@ -48,15 +48,20 @@ namespace Player
     ::Ps3Controller *controller;
     static Ps3Controller *instance;
 
-    static void playRumblePattern(RumbleStep *pattern, int steps);
+    static void playRumblePattern(RumblePattern pattern);
     static void rumbleTask(void *pvParameters);
-    void triggerRumble(RumbleStep *pattern);
+    void triggerRumble(const RumblePattern &pattern);
     void handleOnConnect();
     static void onConnect()
     {
       if (instance)
         instance->handleOnConnect();
     }
+    struct RumbleTaskParams
+    {
+      Ps3Controller *instance;
+      const RumblePattern *pattern;
+    };
   };
 }
 #endif

--- a/include/player/ps3-controller.h
+++ b/include/player/ps3-controller.h
@@ -35,7 +35,7 @@ namespace Player
     AnalogStick leftAnalog() override;
     AnalogStick rightAnalog() override;
 
-    void rumble(RumbleOptions option);
+    void rumble(RumbleOptions option) override;
 
     const uint8_t rawButtonState(const ControllerButton button) const;
     const bool wasPressed(const ControllerButton button) const;

--- a/include/player/rumble.h
+++ b/include/player/rumble.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace Player
+{
+  enum class RumbleOptions
+  {
+    DoublePulse
+  };
+
+  struct RumbleStep
+  {
+    int intensity;
+    int duration;
+  };
+}

--- a/include/player/rumble.h
+++ b/include/player/rumble.h
@@ -1,10 +1,16 @@
 #pragma once
 
+#include <cstddef>
+
+#include "common.h"
+
 namespace Player
 {
   enum class RumbleOptions
   {
-    DoublePulse
+    SingleQuickPulse,
+    DoubleQuickPulse,
+    DeathPulse
   };
 
   struct RumbleStep
@@ -12,4 +18,37 @@ namespace Player
     int intensity;
     int duration;
   };
+
+  class RumblePattern
+  {
+  public:
+    template <uint16_t N>
+    RumblePattern(const RumbleStep (&steps)[N]) : steps(steps), count(N) {}
+
+    const RumbleStep *getSteps() const { return steps; }
+    size_t getCount() const { return count; }
+
+  private:
+    const RumbleStep *steps;
+    size_t count;
+  };
+
+  static const RumbleStep singleQuickSteps[] = {
+      {200, 100}};
+  static const RumbleStep doubleQuickSteps[] = {
+      {200, 100},
+      {0, 100},
+      {200, 100}};
+  static const RumbleStep deathSteps[] = {
+      {255, 100},
+      {0, 100},
+      {255, 400},
+      {0, 100},
+      {255, 100},
+      {0, 100},
+      {255, 400}};
+  static const RumblePattern singleQuickRumbleSeq{singleQuickSteps};
+  static const RumblePattern doubleQuickRumbleSeq{doubleQuickSteps};
+  static const RumblePattern deathRumbleSeq{deathSteps};
+
 }

--- a/include/player/rumble.h
+++ b/include/player/rumble.h
@@ -36,7 +36,7 @@ namespace Player
   static const RumbleStep singleQuickSteps[] = {
       {200, 100}};
   static const RumbleStep doubleQuickSteps[] = {
-      {200, 100},
+      {255, 100},
       {0, 100},
       {200, 100}};
   static const RumbleStep deathSteps[] = {

--- a/src/games/demo/driver.cpp
+++ b/src/games/demo/driver.cpp
@@ -10,6 +10,7 @@ namespace Games::Demo
     {
       incrementCurrentScore();
       contextManager->stateManager.displayShouldUpdate = true;
+      contextManager->controller.rumble(::Player::RumbleOptions::SingleQuickPulse);
       logf("Current score: %d", getCurrentScore());
     }
     auto leftInput = contextManager->controller.leftAnalog();

--- a/src/games/phase-evasion/driver.cpp
+++ b/src/games/phase-evasion/driver.cpp
@@ -129,6 +129,7 @@ namespace Games::PhaseEvasion
         flare.impacted = true;
         state.current = Actions::MuzzleFlash;
         gameOverPhaseShift = static_cast<float>(((SystemCore::Configuration::numLeds() / 2) + player.getPosition()) % SystemCore::Configuration::numLeds());
+        contextManager->controller.rumble(::Player::RumbleOptions::DeathPulse);
         wait(20);
       }
     }
@@ -158,6 +159,7 @@ namespace Games::PhaseEvasion
           gem.capture();
           contextManager->stateManager.getPhaseEvasionGameState().gemsCaptured++;
           contextManager->stateManager.displayShouldUpdate = true;
+          contextManager->controller.rumble(::Player::RumbleOptions::DoubleQuickPulse);
           gem.wait(gemRespawnDelay);
         }
       }

--- a/src/games/phase-evasion/flare-manager.cpp
+++ b/src/games/phase-evasion/flare-manager.cpp
@@ -34,6 +34,7 @@ namespace Games::PhaseEvasion
       {
         contextManager->stateManager.getPhaseEvasionGameState().flaresEvaded++;
         contextManager->stateManager.displayShouldUpdate = true;
+        contextManager->controller.rumble(Player::RumbleOptions::SingleQuickPulse);
         flare.completedCycle = false;
       }
     }

--- a/src/games/recall/driver.cpp
+++ b/src/games/recall/driver.cpp
@@ -115,6 +115,7 @@ namespace Games::Recall
       state.current = Actions::PlayerResponseEvaluation;
       sequenceIndex = 0;
       contextManager->controller.reset();
+      contextManager->controller.rumble(::Player::RumbleOptions::SingleQuickPulse);
       successFadeawayAnimation = 1;
       log("Ready for User playback");
       return;
@@ -136,6 +137,7 @@ namespace Games::Recall
       state.incrementScore();
 
       contextManager->controller.reset();
+      contextManager->controller.rumble(::Player::RumbleOptions::DoubleQuickPulse);
       wait(gameplaySpeedIlluminated * 2);
       return;
     }
@@ -160,6 +162,7 @@ namespace Games::Recall
         }
 
         logf("User provided the incorrect answer. Entering game over sequence.");
+        contextManager->controller.rumble(::Player::RumbleOptions::DeathPulse);
         state.current = Actions::GameOver;
       }
     }

--- a/src/player/ps3-controller.cpp
+++ b/src/player/ps3-controller.cpp
@@ -43,13 +43,24 @@ namespace Player
 
   void Ps3Controller::rumble(RumbleOptions option)
   {
+    const RumblePattern *pattern = nullptr;
+
     switch (option)
     {
-    case RumbleOptions::DoublePulse:
+    case RumbleOptions::DoubleQuickPulse:
+      pattern = &doubleQuickRumbleSeq;
+      break;
+    case RumbleOptions::SingleQuickPulse:
+      pattern = &singleQuickRumbleSeq;
+      break;
+    case RumbleOptions::DeathPulse:
+      pattern = &deathRumbleSeq;
       break;
     default:
       break;
     }
+
+    triggerRumble(*pattern);
   }
 
   const uint8_t Ps3Controller::rawButtonState(const ControllerButton button) const
@@ -172,32 +183,40 @@ namespace Player
     instance->poll();
   }
 
-  void Ps3Controller::playRumblePattern(RumbleStep *pattern, int steps)
+  void Ps3Controller::playRumblePattern(RumblePattern pattern)
   {
-    for (int i = 0; i < steps; i++)
+    const RumbleStep *steps = pattern.getSteps();
+    size_t count = pattern.getCount();
+
+    for (size_t i = 0; i < count; i++)
     {
-      Ps3.setRumble(pattern[i].intensity, pattern[i].duration);
-      delay(pattern[i].duration);
+      Ps3.setRumble(steps[i].intensity, steps[i].duration);
+      vTaskDelay(pdMS_TO_TICKS(steps[i].duration));
     }
   }
 
   void Ps3Controller::rumbleTask(void *pvParameters)
   {
-    RumbleStep *pattern = (RumbleStep *)pvParameters;
-    int steps = 4; // example
+    auto *params = (RumbleTaskParams *)pvParameters;
 
-    playRumblePattern(pattern, steps);
+    Ps3Controller *self = params->instance;
+    const RumblePattern *pattern = params->pattern;
 
+    self->playRumblePattern(*pattern);
+
+    delete params;
     vTaskDelete(NULL);
   }
-
-  void Ps3Controller::triggerRumble(RumbleStep *pattern)
+  void Ps3Controller::triggerRumble(const RumblePattern &pattern)
   {
+    auto *params = new RumbleTaskParams{
+        this,
+        &pattern};
     xTaskCreatePinnedToCore(
         Ps3Controller::rumbleTask,
         "RumbleTask",
         2048,
-        (void *)pattern,
+        (void *)params,
         1,
         NULL,
         0);

--- a/src/player/ps3-controller.cpp
+++ b/src/player/ps3-controller.cpp
@@ -41,6 +41,17 @@ namespace Player
     return joystick;
   }
 
+  void Ps3Controller::rumble(RumbleOptions option)
+  {
+    switch (option)
+    {
+    case RumbleOptions::DoublePulse:
+      break;
+    default:
+      break;
+    }
+  }
+
   const uint8_t Ps3Controller::rawButtonState(const ControllerButton button) const
   {
     if (!instance->connection)
@@ -159,6 +170,37 @@ namespace Player
     instance->ignoreEventsUntil = millis() + 200;
     instance->reset();
     instance->poll();
+  }
+
+  void Ps3Controller::playRumblePattern(RumbleStep *pattern, int steps)
+  {
+    for (int i = 0; i < steps; i++)
+    {
+      Ps3.setRumble(pattern[i].intensity, pattern[i].duration);
+      delay(pattern[i].duration);
+    }
+  }
+
+  void Ps3Controller::rumbleTask(void *pvParameters)
+  {
+    RumbleStep *pattern = (RumbleStep *)pvParameters;
+    int steps = 4; // example
+
+    playRumblePattern(pattern, steps);
+
+    vTaskDelete(NULL);
+  }
+
+  void Ps3Controller::triggerRumble(RumbleStep *pattern)
+  {
+    xTaskCreatePinnedToCore(
+        Ps3Controller::rumbleTask,
+        "RumbleTask",
+        2048,
+        (void *)pattern,
+        1,
+        NULL,
+        0);
   }
 }
 #endif


### PR DESCRIPTION
Support for haptic feedback using the built-in rumble support on the PS3 controller. Points scored, gems captured, and player deaths all result in various rumble speeds, intensities, and sequences.

## Technical Details
The Rumble API only requires on parameter, `Player::RumbleOptions`. The current supported options define their duration, intensity, and overall pattern/sequence. The support options are:
|RumbeOption|Description|
|-|-|
|_SingleQuickPulse_|A soft, quick pulse|
|_DoubleQuickPulse_|Similar to _SingleQuickPulse_, but has two quick soft pulses|
|_DeathPulse_|A stronger rumble to indicate death, represented as Short-Long-Short-Long (K in Morse code)|